### PR TITLE
Add YAML output and testing scaffold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Java
-        uses: actions/setup-java@v3
+      - name: Install sbt
+        uses: coursier/setup-action@v1
         with:
-          distribution: temurin
-          java-version: '21'
+          jvm: temurin:21
+          apps: sbt
       - name: Run sbt fmt check
         run: sbt fmt check

--- a/README.md
+++ b/README.md
@@ -14,5 +14,6 @@ latency‑free RISC‑V instruction semantics.
 sbt fmt check
 
 # export catalogue to YAML
-sbt "sicGen/runMain sicgen.YamlExport" > generated/sic.yaml
+sbt "sicGen/runMain sicgen.YamlExport"
+# output written to generated/sic.yaml
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,8 @@ lazy val sicCore = (project in file("sic-core"))
   .settings(
     name := "sic-core",
     libraryDependencies ++= Seq(
-      "org.typelevel" %% "cats-core" % "2.12.0"
+      "org.typelevel" %% "cats-core" % "2.12.0",
+      "org.scalatest" %% "scalatest" % "3.2.17" % Test
     )
   )
 
@@ -16,6 +17,7 @@ lazy val sicGen = (project in file("sic-gen"))
     name := "sic-gen",
     libraryDependencies ++= Seq(
       "io.circe" %% "circe-yaml" % "0.15.1",
+      "io.circe" %% "circe-generic" % "0.14.6",
       "com.lihaoyi" %% "pprint" % "0.8.1"
     )
   )

--- a/sic-core/src/main/scala/sic/catalogue/Catalogue.scala
+++ b/sic-core/src/main/scala/sic/catalogue/Catalogue.scala
@@ -1,0 +1,6 @@
+package sic.catalogue
+import sic._
+
+object SIC {
+  val catalogue: Vector[InstrDesc] = Vector.empty
+}

--- a/sic-core/src/main/scala/sic/dsl/InstrDSL.scala
+++ b/sic-core/src/main/scala/sic/dsl/InstrDSL.scala
@@ -8,7 +8,13 @@ object InstrDSL {
       format: Format,
       opcode: Int
   )(body: (RegId, Imm) => List[Stmt]): InstrDesc = {
-    // 추후 BitPattern 계산 로직 삽입
-    ???
+    val semantics = body(0, 0)
+    InstrDesc(
+      name = name,
+      format = format,
+      decodeKey = BitPattern.from(opcode, 7),
+      fields = Map.empty,
+      semantics = semantics
+    )
   }
 }

--- a/sic-core/src/main/scala/sic/package.scala
+++ b/sic-core/src/main/scala/sic/package.scala
@@ -1,0 +1,4 @@
+package object sic {
+  type RegId = Int
+  type Imm = Int
+}

--- a/sic-core/src/test/scala/sic/CatalogueSpec.scala
+++ b/sic-core/src/test/scala/sic/CatalogueSpec.scala
@@ -1,0 +1,10 @@
+package sic
+
+import org.scalatest.funsuite.AnyFunSuite
+import sic.catalogue.SIC
+
+class CatalogueSpec extends AnyFunSuite {
+  test("catalogue is defined") {
+    assert(SIC.catalogue != null)
+  }
+}

--- a/sic-gen/src/main/scala/sicgen/YamlExport.scala
+++ b/sic-gen/src/main/scala/sicgen/YamlExport.scala
@@ -1,8 +1,16 @@
 package sicgen
 import sic.catalogue.SIC
-import io.circe.syntax.*
-import io.circe.yaml.syntax.*
+import io.circe.syntax._
+import io.circe.yaml.syntax._
+import io.circe.generic.auto._
+
+import java.nio.file.{Files, Paths}
+import java.nio.charset.StandardCharsets
 
 object YamlExport extends App {
-  println(SIC.catalogue.asYaml.spaces2)
+  val yaml = SIC.catalogue.asJson.asYaml.spaces2
+  val path = Paths.get("generated", "sic.yaml")
+  Files.createDirectories(path.getParent)
+  Files.write(path, yaml.getBytes(StandardCharsets.UTF_8))
+  println(s"Wrote $path")
 }


### PR DESCRIPTION
## Summary
- tweak instruction builder to use 7-bit decode key
- export YAML to `generated/sic.yaml`
- wire ScalaTest and add a basic catalogue spec
- document YAML export in README

## Testing
- `sbt scalafmtAll scalafmtSbt`
- `sbt check`
- `sbt "sicGen/runMain sicgen.YamlExport"`

------
https://chatgpt.com/codex/tasks/task_e_6853646b37ec8325856c0b736b1d9eb3