### PR TITLE
Add extension breakdown

### DIFF
--- a/sic-core/src/main/scala/sic/Format.scala
+++ b/sic-core/src/main/scala/sic/Format.scala
@@ -22,3 +22,7 @@ case object B extends Format
 case object U extends Format
 case object UJ extends Format
 case object CSR extends Format
+// Compressed instruction formats (RVC)
+case object CR extends Format
+case object CI extends Format
+case object CB extends Format

--- a/sic-core/src/main/scala/sic/catalogue/Catalogue.scala
+++ b/sic-core/src/main/scala/sic/catalogue/Catalogue.scala
@@ -18,5 +18,12 @@ object SIC {
 
   /** Full instruction list visible to generators. */
   val catalogue: Vector[sic.InstrDesc] =
-    RV32I.catalogue
+    RV32I.catalogue ++
+      RV32M.catalogue ++
+      RV32A.catalogue ++
+      RV32C.catalogue ++
+      RV32Zba.catalogue ++
+      RV32Zbb.catalogue ++
+      RV32Zbc.catalogue ++
+      RV32Zbs.catalogue
 }

--- a/sic-core/src/main/scala/sic/catalogue/RV32A.scala
+++ b/sic-core/src/main/scala/sic/catalogue/RV32A.scala
@@ -1,0 +1,35 @@
+package sic.catalogue
+
+import sic._
+import sic.dsl.InstrDSL._
+import sic.primitives._
+
+/** Placeholder RV32A atomic instructions. */
+object RV32A {
+  val LR_W = instr("LR.W", R, opcode = 0x2f) { List() }
+  val SC_W = instr("SC.W", R, opcode = 0x2f) { List() }
+  val AMOSWAP_W = instr("AMOSWAP.W", R, opcode = 0x2f) { List() }
+  val AMOADD_W = instr("AMOADD.W", R, opcode = 0x2f) { List() }
+  val AMOXOR_W = instr("AMOXOR.W", R, opcode = 0x2f) { List() }
+  val AMOAND_W = instr("AMOAND.W", R, opcode = 0x2f) { List() }
+  val AMOOR_W = instr("AMOOR.W", R, opcode = 0x2f) { List() }
+  val AMOMIN_W = instr("AMOMIN.W", R, opcode = 0x2f) { List() }
+  val AMOMAX_W = instr("AMOMAX.W", R, opcode = 0x2f) { List() }
+  val AMOMINU_W = instr("AMOMINU.W", R, opcode = 0x2f) { List() }
+  val AMOMAXU_W = instr("AMOMAXU.W", R, opcode = 0x2f) { List() }
+
+  val catalogue: Vector[InstrDesc] =
+    Vector(
+      LR_W,
+      SC_W,
+      AMOSWAP_W,
+      AMOADD_W,
+      AMOXOR_W,
+      AMOAND_W,
+      AMOOR_W,
+      AMOMIN_W,
+      AMOMAX_W,
+      AMOMINU_W,
+      AMOMAXU_W
+    )
+}

--- a/sic-core/src/main/scala/sic/catalogue/RV32C.scala
+++ b/sic-core/src/main/scala/sic/catalogue/RV32C.scala
@@ -1,0 +1,35 @@
+package sic.catalogue
+
+import sic._
+import sic.dsl.InstrDSL._
+import sic.primitives._
+
+/** Placeholder RV32C compressed instructions (subset). */
+object RV32C {
+  val C_ADDI4SPN = instr("C.ADDI4SPN", CI, opcode = 0x0) { List() }
+  val C_LW = instr("C.LW", CI, opcode = 0x0) { List() }
+  val C_SW = instr("C.SW", CI, opcode = 0x0) { List() }
+  val C_NOP = instr("C.NOP", CI, opcode = 0x1) { List() }
+  val C_ADDI = instr("C.ADDI", CI, opcode = 0x1) { List() }
+  val C_J = instr("C.J", CB, opcode = 0x5) { List() }
+  val C_BEQZ = instr("C.BEQZ", CB, opcode = 0x6) { List() }
+  val C_BNEZ = instr("C.BNEZ", CB, opcode = 0x7) { List() }
+  val C_SLLI = instr("C.SLLI", CI, opcode = 0x2) { List() }
+  val C_LWSP = instr("C.LWSP", CI, opcode = 0x2) { List() }
+  val C_SWSP = instr("C.SWSP", CI, opcode = 0x2) { List() }
+
+  val catalogue: Vector[InstrDesc] =
+    Vector(
+      C_ADDI4SPN,
+      C_LW,
+      C_SW,
+      C_NOP,
+      C_ADDI,
+      C_J,
+      C_BEQZ,
+      C_BNEZ,
+      C_SLLI,
+      C_LWSP,
+      C_SWSP
+    )
+}

--- a/sic-core/src/main/scala/sic/catalogue/RV32I.scala
+++ b/sic-core/src/main/scala/sic/catalogue/RV32I.scala
@@ -62,26 +62,68 @@ object RV32I {
   }
 
   // ------------------------------------------------------------------
-  // I‑type  (JALR, … stub)
+  // I‑type (loads, JALR, immediates)
   // ------------------------------------------------------------------
   val JALR: InstrDesc = instr("JALR", I, opcode = 0x67) { List() }
+  val LB: InstrDesc = instr("LB", I, opcode = 0x03) { List() }
+  val LH: InstrDesc = instr("LH", I, opcode = 0x03) { List() }
+  val LW: InstrDesc = instr("LW", I, opcode = 0x03) { List() }
+  val LBU: InstrDesc = instr("LBU", I, opcode = 0x03) { List() }
+  val LHU: InstrDesc = instr("LHU", I, opcode = 0x03) { List() }
+  val ADDI: InstrDesc = instr("ADDI", I, opcode = 0x13) { List() }
+  val SLTI: InstrDesc = instr("SLTI", I, opcode = 0x13) { List() }
+  val SLTIU: InstrDesc = instr("SLTIU", I, opcode = 0x13) { List() }
+  val XORI: InstrDesc = instr("XORI", I, opcode = 0x13) { List() }
+  val ORI: InstrDesc = instr("ORI", I, opcode = 0x13) { List() }
+  val ANDI: InstrDesc = instr("ANDI", I, opcode = 0x13) { List() }
+  val SLLI: InstrDesc = instr("SLLI", I, opcode = 0x13) { List() }
+  val SRLI: InstrDesc = instr("SRLI", I, opcode = 0x13) { List() }
+  val SRAI: InstrDesc = instr("SRAI", I, opcode = 0x13) { List() }
+  val FENCE: InstrDesc = instr("FENCE", I, opcode = 0x0f) { List() }
+  val FENCE_I: InstrDesc = instr("FENCE.I", I, opcode = 0x0f) { List() }
 
-  // TODO: ADDI, SLTI, … loads, etc.
+  // ------------------------------------------------------------------
+  // S‑type (stores)
+  // ------------------------------------------------------------------
+  val SB: InstrDesc = instr("SB", S, opcode = 0x23) { List() }
+  val SH: InstrDesc = instr("SH", S, opcode = 0x23) { List() }
+  val SW: InstrDesc = instr("SW", S, opcode = 0x23) { List() }
 
   // ------------------------------------------------------------------
-  // S‑type (stores)  — stub
+  // B‑type (branches)
   // ------------------------------------------------------------------
-  // val SW: InstrDesc = …
+  val BEQ: InstrDesc = instr("BEQ", B, opcode = 0x63) { List() }
+  val BNE: InstrDesc = instr("BNE", B, opcode = 0x63) { List() }
+  val BLT: InstrDesc = instr("BLT", B, opcode = 0x63) { List() }
+  val BGE: InstrDesc = instr("BGE", B, opcode = 0x63) { List() }
+  val BLTU: InstrDesc = instr("BLTU", B, opcode = 0x63) { List() }
+  val BGEU: InstrDesc = instr("BGEU", B, opcode = 0x63) { List() }
 
   // ------------------------------------------------------------------
-  // B‑type (branches) — stub
+  // R‑type (reg‑reg ALU)
   // ------------------------------------------------------------------
-  // val BEQ: InstrDesc = …
+  val ADD: InstrDesc = instr("ADD", R, opcode = 0x33) { List() }
+  val SUB: InstrDesc = instr("SUB", R, opcode = 0x33) { List() }
+  val SLL: InstrDesc = instr("SLL", R, opcode = 0x33) { List() }
+  val SLT: InstrDesc = instr("SLT", R, opcode = 0x33) { List() }
+  val SLTU: InstrDesc = instr("SLTU", R, opcode = 0x33) { List() }
+  val XOR: InstrDesc = instr("XOR", R, opcode = 0x33) { List() }
+  val SRL: InstrDesc = instr("SRL", R, opcode = 0x33) { List() }
+  val SRA: InstrDesc = instr("SRA", R, opcode = 0x33) { List() }
+  val OR: InstrDesc = instr("OR", R, opcode = 0x33) { List() }
+  val AND: InstrDesc = instr("AND", R, opcode = 0x33) { List() }
 
   // ------------------------------------------------------------------
-  // R‑type (reg‑reg ALU) — stub
+  // CSR‑type (system)
   // ------------------------------------------------------------------
-  // val ADD: InstrDesc = …
+  val ECALL: InstrDesc = instr("ECALL", CSR, opcode = 0x73) { List() }
+  val EBREAK: InstrDesc = instr("EBREAK", CSR, opcode = 0x73) { List() }
+  val CSRRW: InstrDesc = instr("CSRRW", CSR, opcode = 0x73) { List() }
+  val CSRRS: InstrDesc = instr("CSRRS", CSR, opcode = 0x73) { List() }
+  val CSRRC: InstrDesc = instr("CSRRC", CSR, opcode = 0x73) { List() }
+  val CSRRWI: InstrDesc = instr("CSRRWI", CSR, opcode = 0x73) { List() }
+  val CSRRSI: InstrDesc = instr("CSRRSI", CSR, opcode = 0x73) { List() }
+  val CSRRCI: InstrDesc = instr("CSRRCI", CSR, opcode = 0x73) { List() }
 
   // ------------------------------------------------------------------
   // Public aggregated vector
@@ -93,8 +135,54 @@ object RV32I {
       AUIPC,
       // UJ
       JAL,
-      // I
-      JALR
-      // S, B, R … (추가 예정)
+      // I loads & immediates
+      JALR,
+      LB,
+      LH,
+      LW,
+      LBU,
+      LHU,
+      ADDI,
+      SLTI,
+      SLTIU,
+      XORI,
+      ORI,
+      ANDI,
+      SLLI,
+      SRLI,
+      SRAI,
+      FENCE,
+      FENCE_I,
+      // S
+      SB,
+      SH,
+      SW,
+      // B
+      BEQ,
+      BNE,
+      BLT,
+      BGE,
+      BLTU,
+      BGEU,
+      // R
+      ADD,
+      SUB,
+      SLL,
+      SLT,
+      SLTU,
+      XOR,
+      SRL,
+      SRA,
+      OR,
+      AND,
+      // CSR/system
+      ECALL,
+      EBREAK,
+      CSRRW,
+      CSRRS,
+      CSRRC,
+      CSRRWI,
+      CSRRSI,
+      CSRRCI
     )
 }

--- a/sic-core/src/main/scala/sic/catalogue/RV32M.scala
+++ b/sic-core/src/main/scala/sic/catalogue/RV32M.scala
@@ -1,0 +1,20 @@
+package sic.catalogue
+
+import sic._
+import sic.dsl.InstrDSL._
+import sic.primitives._
+
+/** Placeholder RV32M multiplication/division instructions. */
+object RV32M {
+  val MUL = instr("MUL", R, opcode = 0x33) { List() }
+  val MULH = instr("MULH", R, opcode = 0x33) { List() }
+  val MULHSU = instr("MULHSU", R, opcode = 0x33) { List() }
+  val MULHU = instr("MULHU", R, opcode = 0x33) { List() }
+  val DIV = instr("DIV", R, opcode = 0x33) { List() }
+  val DIVU = instr("DIVU", R, opcode = 0x33) { List() }
+  val REM = instr("REM", R, opcode = 0x33) { List() }
+  val REMU = instr("REMU", R, opcode = 0x33) { List() }
+
+  val catalogue: Vector[InstrDesc] =
+    Vector(MUL, MULH, MULHSU, MULHU, DIV, DIVU, REM, REMU)
+}

--- a/sic-core/src/main/scala/sic/catalogue/RV32Zba.scala
+++ b/sic-core/src/main/scala/sic/catalogue/RV32Zba.scala
@@ -1,0 +1,31 @@
+package sic.catalogue
+
+import sic._
+import sic.dsl.InstrDSL._
+import sic.primitives._
+
+/** Placeholder Zba extension instructions. */
+object RV32Zba {
+  val SH1ADD = instr("SH1ADD", R, opcode = 0x33) { List() }
+  val SH2ADD = instr("SH2ADD", R, opcode = 0x33) { List() }
+  val SH3ADD = instr("SH3ADD", R, opcode = 0x33) { List() }
+  val ADD_UW = instr("ADD.UW", R, opcode = 0x33) { List() }
+  val SH1ADD_UW = instr("SH1ADD.UW", R, opcode = 0x33) { List() }
+  val SH2ADD_UW = instr("SH2ADD.UW", R, opcode = 0x33) { List() }
+  val SH3ADD_UW = instr("SH3ADD.UW", R, opcode = 0x33) { List() }
+  val SLLI_UW = instr("SLLI.UW", R, opcode = 0x33) { List() }
+  val ZEXT_W = instr("ZEXT.W", R, opcode = 0x33) { List() }
+
+  val catalogue: Vector[InstrDesc] =
+    Vector(
+      SH1ADD,
+      SH2ADD,
+      SH3ADD,
+      ADD_UW,
+      SH1ADD_UW,
+      SH2ADD_UW,
+      SH3ADD_UW,
+      SLLI_UW,
+      ZEXT_W
+    )
+}

--- a/sic-core/src/main/scala/sic/catalogue/RV32Zbb.scala
+++ b/sic-core/src/main/scala/sic/catalogue/RV32Zbb.scala
@@ -1,0 +1,49 @@
+package sic.catalogue
+
+import sic._
+import sic.dsl.InstrDSL._
+import sic.primitives._
+
+/** Placeholder Zbb extension instructions. */
+object RV32Zbb {
+  val ANDN = instr("ANDN", R, opcode = 0x33) { List() }
+  val ORN = instr("ORN", R, opcode = 0x33) { List() }
+  val XNOR = instr("XNOR", R, opcode = 0x33) { List() }
+  val CLZ = instr("CLZ", R, opcode = 0x33) { List() }
+  val CTZ = instr("CTZ", R, opcode = 0x33) { List() }
+  val CPOP = instr("CPOP", R, opcode = 0x33) { List() }
+  val MAX = instr("MAX", R, opcode = 0x33) { List() }
+  val MAXU = instr("MAXU", R, opcode = 0x33) { List() }
+  val MIN = instr("MIN", R, opcode = 0x33) { List() }
+  val MINU = instr("MINU", R, opcode = 0x33) { List() }
+  val SEXT_B = instr("SEXT.B", R, opcode = 0x33) { List() }
+  val SEXT_H = instr("SEXT.H", R, opcode = 0x33) { List() }
+  val ZEXT_H = instr("ZEXT.H", R, opcode = 0x33) { List() }
+  val ORC_B = instr("ORC.B", R, opcode = 0x33) { List() }
+  val REV8 = instr("REV8", R, opcode = 0x33) { List() }
+  val ROL = instr("ROL", R, opcode = 0x33) { List() }
+  val ROR = instr("ROR", R, opcode = 0x33) { List() }
+  val RORI = instr("RORI", I, opcode = 0x13) { List() }
+
+  val catalogue: Vector[InstrDesc] =
+    Vector(
+      ANDN,
+      ORN,
+      XNOR,
+      CLZ,
+      CTZ,
+      CPOP,
+      MAX,
+      MAXU,
+      MIN,
+      MINU,
+      SEXT_B,
+      SEXT_H,
+      ZEXT_H,
+      ORC_B,
+      REV8,
+      ROL,
+      ROR,
+      RORI
+    )
+}

--- a/sic-core/src/main/scala/sic/catalogue/RV32Zbc.scala
+++ b/sic-core/src/main/scala/sic/catalogue/RV32Zbc.scala
@@ -1,0 +1,15 @@
+package sic.catalogue
+
+import sic._
+import sic.dsl.InstrDSL._
+import sic.primitives._
+
+/** Placeholder Zbc extension instructions. */
+object RV32Zbc {
+  val CLMUL = instr("CLMUL", R, opcode = 0x33) { List() }
+  val CLMULH = instr("CLMULH", R, opcode = 0x33) { List() }
+  val CLMULR = instr("CLMULR", R, opcode = 0x33) { List() }
+
+  val catalogue: Vector[InstrDesc] =
+    Vector(CLMUL, CLMULH, CLMULR)
+}

--- a/sic-core/src/main/scala/sic/catalogue/RV32Zbs.scala
+++ b/sic-core/src/main/scala/sic/catalogue/RV32Zbs.scala
@@ -1,0 +1,20 @@
+package sic.catalogue
+
+import sic._
+import sic.dsl.InstrDSL._
+import sic.primitives._
+
+/** Placeholder Zbs extension instructions. */
+object RV32Zbs {
+  val BCLR = instr("BCLR", R, opcode = 0x33) { List() }
+  val BCLRI = instr("BCLRI", I, opcode = 0x13) { List() }
+  val BEXT = instr("BEXT", R, opcode = 0x33) { List() }
+  val BEXTI = instr("BEXTI", I, opcode = 0x13) { List() }
+  val BINV = instr("BINV", R, opcode = 0x33) { List() }
+  val BINVI = instr("BINVI", I, opcode = 0x13) { List() }
+  val BSET = instr("BSET", R, opcode = 0x33) { List() }
+  val BSETI = instr("BSETI", I, opcode = 0x13) { List() }
+
+  val catalogue: Vector[InstrDesc] =
+    Vector(BCLR, BCLRI, BEXT, BEXTI, BINV, BINVI, BSET, BSETI)
+}


### PR DESCRIPTION
## Summary
- enumerate RV32I catalogue with 47 placeholder entries
- split extension instructions by object: M/A/C and Zb*
- aggregate all catalogues in `SIC`

## Testing
- `sbt fmt`
- `sbt check`


------
https://chatgpt.com/codex/tasks/task_e_685e0d3421d08325af6e8f58ddca76c6